### PR TITLE
Add --fix-missing-replica flag to apply missing GTIDs to replica

### DIFF
--- a/cmd/go-gtids/main.go
+++ b/cmd/go-gtids/main.go
@@ -9,13 +9,14 @@ import (
 )
 
 var (
-	source     = flag.String("s", "", "Source Host")
-	target     = flag.String("t", "", "Target Host")
-	sourcePort = flag.String("source-port", "3306", "Source MySQL port")
-	targetPort = flag.String("target-port", "3306", "Target MySQL port")
-	fix        = flag.Bool("fix", false, "fix the GTID set subset issue by applying to source")
-	fixReplica = flag.Bool("fix-replica", false, "fix the GTID set subset issue by applying to replica")
-	help       = flag.Bool("h", false, "Print help")
+	source            = flag.String("s", "", "Source Host")
+	target            = flag.String("t", "", "Target Host")
+	sourcePort        = flag.String("source-port", "3306", "Source MySQL port")
+	targetPort        = flag.String("target-port", "3306", "Target MySQL port")
+	fix               = flag.Bool("fix", false, "fix the GTID set subset issue by applying to source")
+	fixReplica        = flag.Bool("fix-replica", false, "fix the GTID set subset issue by applying to replica")
+	fixMissingReplica = flag.Bool("fix-missing-replica", false, "fix missing GTIDs by applying dummy transactions to replica")
+	help              = flag.Bool("h", false, "Print help")
 )
 
 func init() {
@@ -23,7 +24,7 @@ func init() {
 }
 
 func printHelp() {
-	fmt.Println("Usage: go-gtids -s <source> -t <target> [-source-port <port>] [-target-port <port>] [-fix] [-fix-replica]")
+	fmt.Println("Usage: go-gtids -s <source> -t <target> [-source-port <port>] [-target-port <port>] [-fix] [-fix-replica] [-fix-missing-replica]")
 }
 
 func main() {
@@ -45,7 +46,7 @@ func main() {
 	defer db1.Close()
 	defer db2.Close()
 
-	err = gtids.CheckGtidSetSubset(db1, db2, *source, *target, *fix, *fixReplica)
+	err = gtids.CheckGtidSetSubset(db1, db2, *source, *target, *fix, *fixReplica, *fixMissingReplica)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error checking GTID set subset: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
- Added fixMissingReplica flag in main.go
- Updated CheckGtidSetSubset to handle missing GTIDs
- Added checkMissingTransactions and applyMissingGtidFixes functions
- Allows automatic injection of missing GTIDs on replica when binary logs are purged