### PR TITLE
Production readiness: safe fix paths, MySQL 8.4+ support, dry-run/confirm, CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,46 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Start MySQL test databases
+        run: |
+          cat > .env << 'EOF'
+          MYSQL_ROOT_PASSWORD=s3cr3t
+          MYSQL_DATABASE=chaos2
+          EOF
+          docker compose up --wait mysql-source mysql-target
+
+      - name: Run full test suite (unit + integration)
+        run: go test -v ./...
+
+      - name: Stop test databases
+        if: always()
+        run: docker compose down -v
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -15,6 +55,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Run unit tests
+        run: go test -short -v ./...
 
       - name: Build macOS binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
           go-version: '1.25'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: latest
 
   test-integration:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ txt_files/
 .my.cnf-FLYWAY
 .my.cnf-*
 !.my.cnf-*.template
+# Build output
+bin/
+dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      # defer x.Close() on read paths is idiomatic; write-path errors are
+      # surfaced by the statements themselves.
+      exclude-functions:
+        - (*database/sql.DB).Close
+        - (*database/sql.Conn).Close
+        - (*database/sql.Rows).Close

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ all: build-docker-go build-docker-pt
 # Testing targets
 test:
 	@echo "Running unit tests..."
-	@go test -v ./pkg/gtids
+	@go test -short -v ./pkg/gtids
 
 test-cover:
 	@echo "Running tests with coverage..."
-	@go test -cover ./pkg/gtids
+	@go test -short -cover ./pkg/gtids
 
 test-integration: test-db-up
 	@echo "Running integration tests..."
-	@go test -v -tags=integration ./pkg/gtids || (make test-db-down; exit 1)
+	@go test -v ./pkg/gtids || (make test-db-down; exit 1)
 	@make test-db-down
 
 test-db-up:

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -1,0 +1,106 @@
+# Production Readiness Plan
+
+Status of the review performed on 2026-07-03 (branch `prod_ready`). Verdict: **not
+production ready yet** — the read-only check path is fine, but the `-fix*` paths have
+correctness bugs that can misbehave against real replication topologies. This file is
+the punch list; check items off as they land.
+
+## P0 — Correctness & safety (must fix before any production use)
+
+- [x] **Session-scoped statements run on a connection pool.**
+  `SET GTID_NEXT`, `SET sql_log_bin=0`, `BEGIN`, `COMMIT` are executed via `db.Exec()`
+  on `*sql.DB`, which is a pool — consecutive statements can land on *different*
+  connections. The empty transaction may commit under the wrong GTID, or with binary
+  logging still enabled. Fix: pin a single `*sql.Conn` for the whole fix sequence.
+- [x] **No cleanup on mid-fix failure.** If applying entries fails partway, the session
+  is left with `GTID_NEXT` set, `sql_log_bin=0`, and replication stopped. Fix: `defer`
+  restoration of `GTID_NEXT='AUTOMATIC'` and `sql_log_bin=1`, and always attempt to
+  restart replication.
+- [x] **MySQL 8.4+ / 9.x incompatibility.** `SHOW MASTER STATUS` and `STOP/START SLAVE`
+  were removed in 8.4. Version detection only recognized `8.0.x`; on 8.4/9.x the tool
+  would issue removed statements and fail (or worse, fail halfway through a fix). Fix:
+  proper semver comparison (>= 8.0.22 → `REPLICA` commands) and
+  `SHOW BINARY LOG STATUS` with fallback to `SHOW MASTER STATUS`.
+- [x] **SQL built by string concatenation.** GTID sets were interpolated directly into
+  `gtid_subtract('...','...')` and `SET GTID_NEXT='...'`. Values come from the server,
+  but a malformed/hostile GTID string still breaks the statement. Fix: placeholders for
+  queries; strict GTID-entry validation before use in `SET GTID_NEXT` (which cannot be
+  parameterized).
+- [x] **Dead/misleading code in the fix path.** A regex tried to match
+  `"Errant Transactions: <gtid>"` against `Executed_Gtid_Set` output — it can never
+  match (the comment even said "even if it seems incorrect"). Removed.
+- [x] **Multi-target loop is a lie.** `strings.Split(target, ",")` iterated "targets"
+  but only one target connection ever exists, so every iteration re-queried the same
+  server. Removed the loop; the CLI takes exactly one target.
+- [x] **`-fix-missing-replica` silently discards data.** Injecting empty transactions
+  for *missing* GTIDs marks them executed on the replica — the source will never send
+  that data again. Legitimate (pt-slave-restart-style) but must warn loudly. Fix:
+  prominent warning printed before applying.
+- [x] **Duplicated fix logic.** `applyMissingGtidFixes` duplicated ~100 lines of the
+  `-fix-replica` orchestration in `CheckGtidSetSubset`. Consolidated into one
+  `applyGtidsToReplica` path so future fixes land in one place.
+
+## P1 — Robustness & UX
+
+- [x] **Connection/read/write timeouts.** DSN now sets `timeout`, `readTimeout`,
+  `writeTimeout` so a hung server can't hang the tool forever.
+- [x] **`-version` flag.** `.goreleaser.yml` injects `main.version/commit/date` ldflags
+  but `main.go` had no such variables, so release binaries had no version info.
+- [x] **`flag.Parse()` in `init()`.** Moved to `main()` (parsing in `init` breaks
+  `go test` flag handling and is a known Go antipattern).
+- [x] **Debug output in normal operation.** `Debug:` prints removed from the
+  replication-status check; user-facing status report kept.
+- [x] **Credentials only from `~/.my.cnf`.** Now honors `MYSQL_USER` / `MYSQL_PASSWORD`
+  env vars as an override, uses `os.UserHomeDir()` (works on Windows builds we ship),
+  and tolerates `user = x` spacing.
+- [x] **`-dry-run` flag** that prints the exact statements a `-fix*` run would execute
+  (including the STOP/START REPLICA orchestration for replica-side fixes).
+- [x] **Confirmation prompt** (`-yes` to skip) before destructive fix operations.
+  Non-interactive runs (cron, closed stdin) hit EOF and abort safely; piping `yes`
+  or passing `-yes` opts in explicitly. Note: scripted `-fix` callers must now add
+  `-yes` — this is an intentional breaking change.
+- [x] **Structured exit codes** so the tool is scriptable in monitoring:
+  0 = in sync (or fix applied), 1 = error, 2 = errant/missing transactions remain
+  (found in check mode, shown in dry-run, or fix declined at the prompt).
+  Caveat: Go's flag package also exits 2 on CLI misuse — distinguishable by the
+  usage text on stderr.
+- [x] **Context plumbing** (`context.Context` through all DB calls) for cancellation
+  via Ctrl-C/SIGTERM. Cleanup paths (GTID_NEXT reset, re-enable binlog, restart
+  replication) use `context.WithoutCancel` so an interrupt mid-fix still restores state.
+- [x] **Retry heuristic** now uses `errors.Is`/`errors.As` against driver error types
+  (bad/invalid conn, `net.Error`, lock-wait-timeout 1205, deadlock 1213) instead of
+  error-string substring matching. Non-retryable errors fail fast.
+
+## P2 — Testing & CI
+
+- [x] **CI never ran tests or vet.** `build.yml` only cross-compiled. Added
+  `go vet` + `go test -short` before builds.
+- [x] **Makefile/test mismatch.** `test-integration` passed `-tags=integration` but no
+  test file has that build tag (they gate on `testing.Short()`), so `make test` was
+  silently running integration tests too. Fixed: `test` uses `-short`,
+  `test-integration` runs the full suite.
+- [x] **No unit coverage of the fix paths.** Added sqlmock tests
+  (`gtid_mock_test.go`) covering: the exact statement sequence of a fix, rejection
+  of invalid/injection GTID entries, GTID_NEXT reset after mid-fix failure, the
+  `SHOW BINARY LOG STATUS` -> `SHOW MASTER STATUS` fallback (both directions),
+  replica column-name handling, retry fail-fast, and context cancellation.
+- [x] **golangci-lint** in CI (validated clean locally with v1.64 first).
+- [x] **Integration test in CI** using the existing docker-compose setup
+  (`test-integration` job in build.yml).
+- [x] **Test the version-detection matrix** — `TestReplicationCommandsForVersion`
+  covers 5.7, 8.0.21, 8.0.22, 8.4, 9.x, MariaDB, and garbage strings.
+
+## P3 — Docs & release hygiene
+
+- [x] **`.gitignore` misses `bin/` and `dist/`** (a built binary was sitting untracked
+  in `bin/`).
+- [x] **README rewrite.** Now: what the tool does, install, flags reference, exit
+  codes, recommended fix workflow, credential setup, dev/testing guide, releases.
+- [x] ~~`CHANGED.md` → `CHANGELOG.md`~~ CHANGED.md turned out to be an *attribution*
+  file (Orchestrator code provenance), not a changelog — left in place and linked
+  from the README credits section. GoReleaser generates release changelogs.
+- [x] **Document `-fix-missing-replica` data-loss semantics** in README (warning
+  section) and in the flag's help text.
+- [x] **Dependabot** added for gomod + github-actions (weekly).
+- [ ] **Pin GitHub Actions by SHA** (supply-chain hygiene) — needs SHA lookup per
+  action; dependabot will keep them fresh once pinned.

--- a/README.md
+++ b/README.md
@@ -1,135 +1,178 @@
 # go-gtids
 
-A Go App To Check For Errant Transactions
+Check a MySQL source/replica pair for **errant transactions** (GTIDs executed on the
+replica that the source never saw) and optionally reconcile them — the GTID-set
+comparison equivalent of `pt-slave-restart`-era triage, in a single static binary.
+
+```console
+$ go-gtids -s 10.5.0.152 -t 10.5.0.153
+[+] Source -> 10.5.0.152 gtid_executed: 1d1fff5a-...:1, c4709bcc-...:1-33
+[+] server_uuid: c4709bcc-c9bb-11ed-8d19-02a36d996b94
+[+] Target -> 10.5.0.153 gtid_executed: 1d1fff5a-...:1-2, c4709bcc-...:1-33
+[+] server_uuid: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94
+[-] Errant Transactions: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:2
+[-] Errant Transaction Found in Log Name: binlog.000002
+```
+
+Works with MySQL 5.7, 8.0, 8.4, and 9.x (it picks `STOP SLAVE` vs `STOP REPLICA`
+and `SHOW MASTER STATUS` vs `SHOW BINARY LOG STATUS` automatically).
+
+## Install
+
+Download a binary from the [releases page](https://github.com/ChaosHour/go-gtids/releases)
+(macOS, Linux, Windows; amd64 and arm64), or build from source:
+
+```bash
+go install github.com/ChaosHour/go-gtids/cmd/go-gtids@latest
+# or
+make build            # builds ./bin/go-gtids for the current platform
+```
 
 ## Usage
 
-```Go
-./bin/go-gtids -h
-Usage: go-gtids -s <source> -t <target> [-source-port <port>] [-target-port <port>] [-fix] [-fix-replica]
+```text
+go-gtids -s <source> -t <target> [flags]
 
-./bin/go-gtids -help
-Usage of ./bin/go-gtids-macos:
-  -fix
-        fix the GTID set subset issue by applying to source
-  -fix-replica
-        fix the GTID set subset issue by applying to replica
-  -h    Print help
-  -s string
-        Source Host
-  -source-port string
-        Source MySQL port (default "3306")
-  -t string
-        Target Host
-  -target-port string
-        Target MySQL port (default "3306")
-
+  -s string              Source host (the primary)
+  -t string              Target host (the replica)
+  -source-port string    Source MySQL port (default "3306")
+  -target-port string    Target MySQL port (default "3306")
+  -fix                   Apply errant GTIDs as empty transactions on the SOURCE
+  -fix-replica           Apply errant GTIDs as empty transactions on the REPLICA
+  -fix-missing-replica   Mark GTIDs missing on the replica as executed (see warning)
+  -dry-run               Print the statements a fix would execute without running them
+  -yes                   Skip the confirmation prompt before applying fixes
+  -version               Print version and exit
+  -h                     Print help
 ```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Source and target are in sync (or a fix was applied successfully) |
+| 1 | Operational error (connection, query, fix failure) |
+| 2 | Errant/missing transactions remain (check mode, dry-run, or fix declined) |
+
+This makes the tool scriptable for monitoring:
+
+```bash
+go-gtids -s primary -t replica || alert "GTID drift detected"
+```
+
+### Fixing errant transactions
+
+The recommended workflow:
+
+```bash
+# 1. See what would happen
+go-gtids -s primary -t replica -fix -dry-run
+
+# 2. Apply (prompts for confirmation; -yes skips the prompt for automation)
+go-gtids -s primary -t replica -fix -yes
+```
+
+`-fix` injects each errant GTID as an **empty transaction on the source**, so the
+GTID set converges across the topology. The empty transactions replicate downstream
+and are automatically skipped by servers that already executed them. This makes a
+future failover safe; **it does not sync data** — if the errant transaction changed
+rows, reconcile the data separately (e.g. with
+[data-diff](https://github.com/datafold/data-diff)).
+
+All fixes run on a single pinned connection, always reset `GTID_NEXT` afterwards
+(even on failure), and replica-side fixes always restart replication (even on
+failure or Ctrl-C).
+
+### ⚠️ `-fix-missing-replica`
+
+This flag handles the opposite direction: GTIDs the **source** has that the replica
+is missing. It marks them as executed on the replica **without applying their
+data** — the source will never resend those transactions. Use it only when you know
+the data is already consistent (or will be synced out-of-band); the tool prints a
+warning and prompts before proceeding.
 
 ## Credentials
 
-```Go
-The credentials are stored in the ~/.my.cnf file in the users home directory and are read by the app.
+Credentials are resolved in this order:
 
-// read the ~/.my.cnf file to get the database credentials
-func readMyCnf() {
-    file, err := ioutil.ReadFile(os.Getenv("HOME") + "/.my.cnf")
-    if err != nil {
-        log.Fatal(err)
-}
-    lines := strings.Split(string(file), "\n")
-    for _, line := range lines {
-        if strings.HasPrefix(line, "user") {
-             os.Setenv("MYSQL_USER", strings.TrimSpace(line[5:]))
-        }
-        if strings.HasPrefix(line, "password") {
-             os.Setenv("MYSQL_PASSWORD", strings.TrimSpace(line[9:]))
-        }
-    }
-}
+1. `MYSQL_USER` and `MYSQL_PASSWORD` environment variables (both must be set)
+2. `~/.my.cnf`:
 
-
-
-cat ~/.my.cnf
+```ini
 [client]
 user=root
 password=s3cr3t
-
-[client_primary1]
-host=192.168.50.50
-port=3306
-
-[client_replica1]
-host=192.168.50.50
-port=3307
 ```
 
-## Example
+The same credentials are used for both hosts. Connections carry 10s dial and
+60s read/write timeouts.
 
-```Go
-Testing MySQL 8 & GTID's
+## Development
 
-mysql --version
-mysql  Ver 8.0.32-24 for Linux on x86_64 (Percona Server (GPL), Release '24', Revision 'e5c6e9d2')
-
-
-root@replica:~# mysql -e "select * from  book.million_words LIMIT 1"
-+--------+---------+
-| id     | word    |
-+--------+---------+
-| 212036 | a'irahS |
-+--------+---------+
-
-
-root@replica:~# mysql -e "delete from book.million_words where id = 212036 limit 1"
-
-
-
-Checked for Errant Transactions:  -s = <primary> -t = <replica>
-
-(data-sync) klarsen@Mac-Book-Pro2 data-sync % ./go-gtids -s 10.5.0.152 -t 10.5.0.153
-[+] Source gtid_executed: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1,
-c4709bcc-c9bb-11ed-8d19-02a36d996b94:1-33
-[+] Target gtid_executed: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-2,
-c4709bcc-c9bb-11ed-8d19-02a36d996b94:1-33
-[-] Errant Transactions: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:2
-
-
-Ran on the primary to resolve; other method is to reset master on the replica:
-root@primary:~# mysql -e "SET GTID_NEXT='1d1fff5a-c9bc-11ed-9c19-02a36d996b94:2';BEGIN; COMMIT;SET GTID_NEXT='AUTOMATIC'"
-
-
-
-Then checked again:
-
-(data-sync) klarsen@Mac-Book-Pro2 data-sync % ./go-gtids -s 10.5.0.152 -t 10.5.0.153
-[+] Source gtid_executed: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-2,
-c4709bcc-c9bb-11ed-8d19-02a36d996b94:1-33
-[+] Target gtid_executed: 1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-2,
-c4709bcc-c9bb-11ed-8d19-02a36d996b94:1-33
-[+] Errant Transactions: 
-
-
-
-Validated data:
-(data-sync) klarsen@Mac-Book-Pro2 data-sync % data-diff \
-mysql://dba:xxxxx@10.5.0.152:3306/book million_words \
-mysql://dba:xxxxx@10.5.0.153:3306/book million_words
-- 212036
-
-The Errant Transaction was resolved. You will still need to sync your data.
+```bash
+make build              # build ./bin/go-gtids
+make test               # unit tests (no database needed)
+make test-integration   # spins up two MySQL 8.0 containers via docker compose
+make test-cover         # unit tests with coverage
 ```
 
-## Tools Used for Data validation
+Integration tests need a `.env` file (gitignored) for docker compose:
 
-- [Data-Diff](https://github.com/datafold/data-diff)
+```bash
+cat > .env << 'EOF'
+MYSQL_ROOT_PASSWORD=s3cr3t
+MYSQL_DATABASE=chaos2
+EOF
+```
 
-## Working on adding some more functionality to this Go App to make it more useful
+The compose setup starts `mysql-source` (port 3306) and `mysql-target` (port 3307)
+with GTID mode enabled. Test credentials are configurable via `TEST_MYSQL_USER`,
+`TEST_MYSQL_PASSWORD`, `TEST_MYSQL_HOST`, and `TEST_MYSQL_PORT` (defaults:
+`root` / `s3cr3t` / `127.0.0.1` / `3306`).
 
-- Added code and the logic to check for Errant Transactions.
-- Added a -fix flag to fix the errant transaction by applying dummy transactions to the Primary.
-- Added a -fix-replica flag to fix the errant transaction by applying dummy transactions directly to the Replica.
-- The -fix-replica method safely stops replication, disables binary logging, applies GTIDs, re-enables logging, and restarts replication.
+To create an errant transaction to play with, write directly to the replica:
+
+```bash
+mysql -h 127.0.0.1 -P 3307 -e "CREATE DATABASE oops; DROP DATABASE oops;"
+```
+
+CI runs `go vet`, unit tests, golangci-lint, and the integration suite on every
+push and pull request.
+
+## Releases
+
+Tagging `v*.*.*` triggers [GoReleaser](https://goreleaser.com/) via GitHub Actions:
+binaries for macOS/Linux/Windows (amd64/arm64), archives, SHA256 checksums, and a
+changelog. Test locally with `make release-dry-run`.
+
+### Cutting a release, step by step
+
+Work happens on a branch and lands on `main` via a pull request; a version tag
+then cuts the release:
+
+```bash
+# 1. Branch, commit, push
+git checkout -b my-feature
+git add -p && git commit -m "feat: describe the change"
+git push -u origin my-feature
+
+# 2. Open a pull request (CI runs lint, unit + integration tests, builds)
+gh pr create --base main --title "feat: describe the change" \
+  --body "What changed and why"
+
+# 3. After the PR merges, tag main to release.
+#    Bump MAJOR for breaking CLI changes, MINOR for features, PATCH for fixes.
+git checkout main && git pull
+git tag v2.0.0
+git push origin v2.0.0        # <- this triggers the Release workflow
+
+# 4. Watch it build, then check the release
+gh run watch
+gh release view v2.0.0
+```
+
+The version embedded in the binary comes from the tag automatically
+(`go-gtids -version`).
 
 ## Screenshots
 
@@ -137,429 +180,8 @@ The Errant Transaction was resolved. You will still need to sync your data.
 
 ![Fix GTIDs screenshot](screenshots/Fix_GTIDs.png)
 
-## Added a show me which binlog file by name has the errant transaction(s) by default
-
-![GTIDs binlog screenshot](screenshots/Gtids_binlog.png)
-
-![GTIDs check binlog screenshot](screenshots/Gtids_check_binlog.png)
-
-![GTIDs fix check screenshot](screenshots/Gtids_fix_check.png)
-
-```Go
-To build:
-
-go build -o go-gtids
-
-FreeBSD:
-env GOOS=freebsd GOARCH=amd64 go build .
-
-On Mac:
-env GOOS=darwin GOARCH=amd64 go build .
-
-Linux:
-env GOOS=linux GOARCH=amd64 go build .
-```
-
-## I added a couple of Dockerfiles and a Makefile to help build for testing
-
-```bash
-make all
-
-docker run --network mysql57-docker-gtids_db-network go-gtids -s 172.25.0.3 -t 172.25.0.2
-[+] Source -> 172.25.0.3 gtid_executed: 874d7e24-2292-11ef-bc48-0242ac190003:1-3966,
-c04d4193-2292-11ef-bcdd-0242ac190002:1-4
-[+] server_uuid: 874d7e24-2292-11ef-bc48-0242ac190003
-[+] Target -> 172.25.0.2 gtid_executed: 874d7e24-2292-11ef-bc48-0242ac190003:1-3966,
-c04d4193-2292-11ef-bcdd-0242ac190002:1-4
-[+] server_uuid: c04d4193-2292-11ef-bcdd-0242ac190002
-[+] No Errant Transactions:
-
-
-
-docker run --network mysql57-docker-gtids_db-network pt-slave-restart -h 172.25.0.2
-
-docker run --network mysql57-docker-gtids_db-network pt-slave-restart --master-uuid b33e4e58-21de-11ef-a136-0242ac190003 -h 172.25.0.2
-
-```
-
-## Test using go-gtids and pt-slave-restart
-
-```bash
-Replication borked on purpose ...
-
-              Last_SQL_Errno: 1007
-               Last_SQL_Error: Error 'Can't create database 'chaos'; database exists' on query. Default database: 'chaos'. Query: 'create database `chaos`'
-  Replicate_Ignore_Server_Ids:
-             Master_Server_Id: 1
-                  Master_UUID: b33e4e58-21de-11ef-a136-0242ac190003
-             Master_Info_File: mysql.slave_master_info
-                    SQL_Delay: 0
-          SQL_Remaining_Delay: NULL
-      Slave_SQL_Running_State:
-           Master_Retry_Count: 86400
-                  Master_Bind:
-      Last_IO_Error_Timestamp:
-     Last_SQL_Error_Timestamp: 240604 15:48:53
-               Master_SSL_Crl:
-           Master_SSL_Crlpath:
-           Retrieved_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-5967,
-ec45394f-21de-11ef-a23d-0242ac190002:5-7
-            Executed_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-3976,
-ec45394f-21de-11ef-a23d-0242ac190002:1-7
-                Auto_Position: 1
-
-
-
-
-
-Does not register as an Errant transaction, hmm:
-
-docker run --network mysql57-docker-gtids_db-network go-gtids -s 172.25.0.3 -t 172.25.0.2
-[+] Source -> 172.25.0.3 gtid_executed: b33e4e58-21de-11ef-a136-0242ac190003:1-5967,
-ec45394f-21de-11ef-a23d-0242ac190002:1-7
-[+] server_uuid: b33e4e58-21de-11ef-a136-0242ac190003
-[+] Target -> 172.25.0.2 gtid_executed: b33e4e58-21de-11ef-a136-0242ac190003:1-3976,
-ec45394f-21de-11ef-a23d-0242ac190002:1-7
-[+] server_uuid: ec45394f-21de-11ef-a23d-0242ac190002
-[+] No Errant Transactions:
-
-
-
-
-mysql --defaults-group-suffix=_replica1 -e "show slave status\G" | awk -v RS='\n ' '
-{
-    if ($1 ~ /Master_Host|Slave_IO_Running|Slave_SQL_Running|Seconds_Behind_Master|Retrieved_Gtid_Set|Executed_Gtid_Set/) {
-        split($0, a, ": ");
-        print a[1] ": " substr($0, index($0, a[2]));
-    }
-}'
-                 Master_Host: 172.25.0.3
-            Slave_IO_Running: Yes
-           Slave_SQL_Running: No
-       Seconds_Behind_Master: NULL
-Master_SSL_Verify_Server_Cert: No
-     Slave_SQL_Running_State:      Slave_SQL_Running_State:
-          Retrieved_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-5967,
-ec45394f-21de-11ef-a23d-0242ac190002:5-7
-           Executed_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-3976,
-ec45394f-21de-11ef-a23d-0242ac190002:1-7
-
-
-
-
-
-Do you have to set --master-uuid? No it still worked without adding that argument.
-
-docker run --network mysql57-docker-gtids_db-network pt-slave-restart --master-uuid b33e4e58-21de-11ef-a136-0242ac190003 -h 172.25.0.2
-2024-06-04T16:15:06 h=172.25.0.2 relay-log-bin.000005         658 1007
-
-
-
-
-mysql --defaults-group-suffix=_replica1 -e "show slave status\G" | awk -v RS='\n ' '
-{
-    if ($1 ~ /Master_Host|Slave_IO_Running|Slave_SQL_Running|Seconds_Behind_Master|Retrieved_Gtid_Set|Executed_Gtid_Set/) {
-        split($0, a, ": ");
-        print a[1] ": " substr($0, index($0, a[2]));
-    }
-}'
-                 Master_Host: 172.25.0.3
-            Slave_IO_Running: Yes
-           Slave_SQL_Running: Yes
-       Seconds_Behind_Master: 28684
-Master_SSL_Verify_Server_Cert: No
-     Slave_SQL_Running_State: creating table
-          Retrieved_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-5967,
-ec45394f-21de-11ef-a23d-0242ac190002:5-7
-           Executed_Gtid_Set: b33e4e58-21de-11ef-a136-0242ac190003:1-4856,
-ec45394f-21de-11ef-a23d-0242ac190002:1-7
-```
-
-## Example with Errant Transactions in a Docker Container
-
-```Go
-./bin/go-gtids -s 192.168.50.50 -source-port 3306 -t 192.168.50.50 -target-port 3307
-[+] Source -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39
-[+] server_uuid: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc
-[+] Target -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39,
-35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[+] server_uuid: 35e31a1e-1c26-11f0-b708-f6db8cba6bab
-[-] Errant Transactions: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[-] Errant Transaction Found in Log Name: binlog.000002
-
-
-
-mysql --defaults-group-suffix=_replica1 -e "show slave status\G" | awk -v RS='\n ' '
-{
-    if ($1 ~ /Master_Host|Slave_IO_Running|Slave_SQL_Running|Seconds_Behind_Master|Retrieved_Gtid_Set|Executed_Gtid_Set/) {
-        split($0, a, ": ");
-        print a[1] ": " substr($0, index($0, a[2]));
-    }
-}'
-                 Master_Host: 172.20.0.3
-            Slave_IO_Running: Yes
-           Slave_SQL_Running: Yes
-       Seconds_Behind_Master: 0
-Master_SSL_Verify_Server_Cert: No
-     Slave_SQL_Running_State: Replica has read all relay log; waiting for more updates
-          Retrieved_Gtid_Set: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39
-           Executed_Gtid_Set: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39,
-35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-
-./bin/go-gtids -s 192.168.50.50 -source-port 3306 -t 192.168.50.50 -target-port 3307 -fix
-[+] Source -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39
-[+] server_uuid: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc
-[+] Target -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39,
-35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[+] server_uuid: 35e31a1e-1c26-11f0-b708-f6db8cba6bab
-[-] Errant Transactions: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[-] Errant Transaction Found in Log Name: binlog.000002
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:1
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:2
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:3
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:4
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:5
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:6
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:7
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:8
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:9
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:10
-Applied entry: 35e31a1e-1c26-11f0-b708-f6db8cba6bab:11
-
-
-./bin/go-gtids -s 192.168.50.50 -source-port 3306 -t 192.168.50.50 -target-port 3307
-[+] Source -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39,
-35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[+] server_uuid: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc
-[+] Target -> 192.168.50.50 gtid_executed: 35dacfbe-1c26-11f0-ab3a-3eaa1b6dc9dc:1-39,
-35e31a1e-1c26-11f0-b708-f6db8cba6bab:1-11
-[+] server_uuid: 35e31a1e-1c26-11f0-b708-f6db8cba6bab
-[+] No Errant Transactions: 
-```
-
-## Testing
-
-The project includes comprehensive testing infrastructure with Docker-based MySQL instances and realistic test data.
-
-### ✅ Testing Status
-
-The testing infrastructure is fully functional:
-
-- ✅ Docker Compose setup with MySQL 8.0 instances
-- ✅ GTID detection working correctly
-- ✅ Errant transaction fixing working correctly  
-- ✅ Test data loaded and generating realistic scenarios
-- ✅ Integration tests passing
-
-### Quick Start Testing
-
-1. **Start test databases:**
-
-   ```bash
-   make test-db-up
-   ```
-
-2. **Run unit tests:**
-
-   ```bash
-   make test
-   ```
-
-3. **Run tests with coverage:**
-
-   ```bash
-   make test-cover
-   ```
-
-4. **Run integration tests:**
-
-   ```bash
-   make test-integration
-   ```
-
-5. **Stop test databases:**
-
-   ```bash
-   make test-db-down
-   ```
-
-### Test Database Setup
-
-The `docker-compose.yml` creates two MySQL 8.0 instances:
-
-- **mysql-source**: Port 3306, Server ID 1
-- **mysql-target**: Port 3307, Server ID 2
-
-Both instances are configured with:
-
-- GTID mode enabled
-- Binary logging enabled
-- Test database `chaos2` with sample data
-- Root user credentials (from `.env` file)
-
-### Environment Configuration
-
-Database passwords and configuration are stored in a `.env` file:
-
-```bash
-# Create .env file
-cat > .env << 'EOF'
-MYSQL_ROOT_PASSWORD=your_secure_password
-MYSQL_DATABASE=chaos2
-EOF
-
-# The .env file is automatically loaded by docker-compose
-```
-
-**Note**: The `.env` file is excluded from version control for security.
-
-### Test Data
-
-The `sql/` directory contains comprehensive test schemas:
-
-- **`tables.sql`**: Complete e-commerce schema with users, orders, products, and audit logs
-- **`tables2.sql`**: GTID-specific test scenarios for creating errant transactions
-
-### SSL Configuration for Testing
-
-If you encounter connection issues with SSL, you can temporarily disable SSL for testing:
-
-```bash
-# Backup your config
-cp ~/.my.cnf ~/.my.cnf.backup
-
-# Create test config with SSL disabled
-cat > ~/.my.cnf << 'EOF'
-[client]
-ssl-mode=DISABLED
-user=root
-password=your_password
-EOF
-
-# Run tests...
-make test-integration
-
-# Restore original config
-cp ~/.my.cnf.backup ~/.my.cnf
-```
-
-### Manual Testing
-
-Connect to test databases:
-
-```bash
-# Test connection (non-interactive)
-make test-db-ping-source
-make test-db-ping-target
-
-# Interactive shell
-make test-db-shell-source
-make test-db-shell-target
-
-# Or use the script directly:
-./db-shell.sh source query    # Test connection
-./db-shell.sh target shell    # Interactive shell
-```
-
-Run go-gtids against test instances:
-
-```bash
-# Build for testing
-make build
-
-# Test basic functionality
-make test-gtids
-
-# Test with fix
-make test-gtids-fix
-
-# Test with fix-replica
-make test-gtids-fix-replica
-```
-
-### Docker Testing
-
-Build test container:
-
-```bash
-make build-docker-test
-```
-
-Run in Docker:
-
-```bash
-docker run --network host go-gtids-test -s 127.0.0.1 -t 127.0.0.1 -target-port 3307
-```
-
-### Test Scenarios
-
-The SQL files enable testing of:
-
-1. **Basic GTID Detection**: Verify tool detects differences between source and target
-2. **Errant Transaction Fixing**: Test `-fix` and `-fix-replica` functionality
-3. **Bulk Operations**: Performance testing with large datasets
-4. **Conflict Simulation**: Test complex replication scenarios
-5. **Schema Drift**: Test handling of structural differences
-
-### Troubleshooting
-
-View database logs:
-
-```bash
-make test-db-logs
-```
-
-Check database health:
-
-```bash
-docker-compose ps
-docker-compose exec mysql-source mysqladmin ping
-```
-
-## Releases
-
-This project uses [GoReleaser](https://goreleaser.com/) to automate releases for multiple platforms.
-
-### Supported Platforms
-
-Releases are automatically built for:
-- **macOS** (amd64, arm64)
-- **Linux** (amd64, arm64)
-- **Windows** (amd64, arm64)
-
-### Creating a Release
-
-1. **Tag the release:**
-   ```bash
-   git tag v1.0.0
-   git push origin v1.0.0
-   ```
-
-2. **GitHub Actions will automatically:**
-   - Build binaries for all platforms
-   - Create archives (tar.gz for Unix, zip for Windows)
-   - Generate checksums
-   - Create a GitHub release with changelog
-
-### Local Release Testing
-
-Test the release process locally:
-
-```bash
-# Install GoReleaser (if not already installed)
-go install github.com/goreleaser/goreleaser@latest
-
-# Dry run (doesn't create release)
-make release-dry-run
-
-# Build locally without publishing
-make release-local
-```
-
-### Release Artifacts
-
-Each release includes:
-- Binary executables for each platform
-- Compressed archives
-- SHA256 checksums file
-- Auto-generated changelog
+## Credits
+
+The GTID-set parsing code originates from
+[Orchestrator](https://github.com/openark/orchestrator) by Shlomi Noach
+(Apache 2.0) — see [CHANGED.md](CHANGED.md) for details.

--- a/cmd/go-gtids/main.go
+++ b/cmd/go-gtids/main.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ChaosHour/go-gtids/pkg/gtids"
+)
+
+// Populated by goreleaser via -ldflags at release time.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 var (
@@ -15,19 +25,27 @@ var (
 	targetPort        = flag.String("target-port", "3306", "Target MySQL port")
 	fix               = flag.Bool("fix", false, "fix the GTID set subset issue by applying to source")
 	fixReplica        = flag.Bool("fix-replica", false, "fix the GTID set subset issue by applying to replica")
-	fixMissingReplica = flag.Bool("fix-missing-replica", false, "fix missing GTIDs by applying dummy transactions to replica")
+	fixMissingReplica = flag.Bool("fix-missing-replica", false, "fix missing GTIDs by applying dummy transactions to replica (WARNING: skips the transactions' data)")
+	dryRun            = flag.Bool("dry-run", false, "print the statements a fix would execute without running them")
+	assumeYes         = flag.Bool("yes", false, "skip the confirmation prompt before applying fixes")
+	showVersion       = flag.Bool("version", false, "Print version and exit")
 	help              = flag.Bool("h", false, "Print help")
 )
 
-func init() {
-	flag.Parse()
-}
-
 func printHelp() {
-	fmt.Println("Usage: go-gtids -s <source> -t <target> [-source-port <port>] [-target-port <port>] [-fix] [-fix-replica] [-fix-missing-replica]")
+	fmt.Println("Usage: go-gtids -s <source> -t <target> [-source-port <port>] [-target-port <port>] [-fix] [-fix-replica] [-fix-missing-replica] [-dry-run] [-yes]")
+	flag.PrintDefaults()
+	fmt.Println("Exit codes: 0 = in sync (or fix applied), 1 = error, 2 = errant/missing transactions remain")
 }
 
 func main() {
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("go-gtids %s (commit %s, built %s)\n", version, commit, date)
+		os.Exit(0)
+	}
+
 	if *help {
 		printHelp()
 		os.Exit(0)
@@ -38,7 +56,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	db1, db2, err := gtids.ConnectToDatabases(*source, *sourcePort, *target, *targetPort)
+	if *dryRun && !*fix && !*fixReplica && !*fixMissingReplica {
+		fmt.Fprintln(os.Stderr, "Note: -dry-run has no effect without -fix, -fix-replica, or -fix-missing-replica")
+	}
+
+	// Ctrl-C / SIGTERM cancels in-flight work; fix cleanup still runs to completion.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	db1, db2, err := gtids.ConnectToDatabases(ctx, *source, *sourcePort, *target, *targetPort)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error connecting to databases: %v\n", err)
 		os.Exit(1)
@@ -46,9 +72,18 @@ func main() {
 	defer db1.Close()
 	defer db2.Close()
 
-	err = gtids.CheckGtidSetSubset(db1, db2, *source, *target, *fix, *fixReplica, *fixMissingReplica)
+	unresolved, err := gtids.CheckGtidSetSubset(ctx, db1, db2, *source, *target, gtids.Options{
+		Fix:               *fix,
+		FixReplica:        *fixReplica,
+		FixMissingReplica: *fixMissingReplica,
+		DryRun:            *dryRun,
+		AssumeYes:         *assumeYes,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error checking GTID set subset: %v\n", err)
 		os.Exit(1)
+	}
+	if unresolved {
+		os.Exit(2)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ChaosHour/go-gtids
 go 1.25
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/fatih/color v1.17.0
 	github.com/go-sql-driver/mysql v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/pkg/gtids/db.go
+++ b/pkg/gtids/db.go
@@ -1,87 +1,119 @@
 package gtids
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 )
 
-// ReadMyCnf reads the ~/.my.cnf file to get the database credentials
+// ReadMyCnf returns the database credentials, preferring the MYSQL_USER and
+// MYSQL_PASSWORD environment variables and falling back to ~/.my.cnf.
 func ReadMyCnf() (user, password string, err error) {
-	file, err := os.ReadFile(os.Getenv("HOME") + "/.my.cnf")
+	user = os.Getenv("MYSQL_USER")
+	password = os.Getenv("MYSQL_PASSWORD")
+	if user != "" && password != "" {
+		return user, password, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to locate home directory: %w", err)
+	}
+	file, err := os.ReadFile(filepath.Join(home, ".my.cnf"))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read ~/.my.cnf: %w", err)
 	}
-	lines := strings.Split(string(file), "\n")
-	for _, line := range lines {
+	for _, line := range strings.Split(string(file), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "user=") {
-			user = strings.TrimSpace(line[5:])
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
 		}
-		if strings.HasPrefix(line, "password=") {
-			password = strings.TrimSpace(line[9:])
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		switch key {
+		case "user":
+			if user == "" {
+				user = value
+			}
+		case "password":
+			if password == "" {
+				password = value
+			}
 		}
 	}
 	if user == "" || password == "" {
-		return "", "", fmt.Errorf("user and password not found in ~/.my.cnf")
+		return "", "", fmt.Errorf("user and password not found in ~/.my.cnf (or set MYSQL_USER and MYSQL_PASSWORD)")
 	}
 	return user, password, nil
 }
 
+// sleepCtx sleeps for d or until ctx is cancelled, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
 // connectWithRetry attempts to connect to a database with retry logic for transient failures
-func connectWithRetry(dsn string, maxRetries int) (*sql.DB, error) {
+func connectWithRetry(ctx context.Context, dsn string, maxRetries int) (*sql.DB, error) {
 	var db *sql.DB
 	var err error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		db, err = sql.Open("mysql", dsn)
-		if err != nil {
-			if attempt == maxRetries {
-				return nil, fmt.Errorf("failed to open database connection after %d attempts: %w", maxRetries, err)
+		if err == nil {
+			err = db.PingContext(ctx)
+			if err == nil {
+				return db, nil
 			}
-			time.Sleep(time.Duration(attempt) * 100 * time.Millisecond) // Exponential backoff
-			continue
-		}
-
-		err = db.Ping()
-		if err != nil {
 			db.Close()
-			if attempt == maxRetries {
-				return nil, fmt.Errorf("failed to ping database after %d attempts: %w", maxRetries, err)
-			}
-			time.Sleep(time.Duration(attempt) * 100 * time.Millisecond) // Exponential backoff
-			continue
 		}
-
-		// Success
-		return db, nil
+		if attempt == maxRetries {
+			return nil, fmt.Errorf("failed to connect after %d attempts: %w", maxRetries, err)
+		}
+		if serr := sleepCtx(ctx, time.Duration(attempt)*100*time.Millisecond); serr != nil {
+			return nil, serr
+		}
 	}
 
 	return nil, fmt.Errorf("unexpected error in connection retry logic")
 }
 
 // ConnectToDatabases connects to the source and target databases with retry logic
-func ConnectToDatabases(sourceHost, sourcePort, targetHost, targetPort string) (db1, db2 *sql.DB, err error) {
+func ConnectToDatabases(ctx context.Context, sourceHost, sourcePort, targetHost, targetPort string) (db1, db2 *sql.DB, err error) {
 	user, password, err := ReadMyCnf()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read MySQL credentials: %w", err)
 	}
 
-	sourceDSN := fmt.Sprintf("%s:%s@tcp(%s:%s)/mysql", user, password, sourceHost, sourcePort)
-	targetDSN := fmt.Sprintf("%s:%s@tcp(%s:%s)/mysql", user, password, targetHost, targetPort)
+	// Connection/read/write timeouts so a hung server can't hang the tool forever.
+	const dsnOptions = "?timeout=10s&readTimeout=1m&writeTimeout=1m"
+	sourceDSN := fmt.Sprintf("%s:%s@tcp(%s:%s)/mysql%s", user, password, sourceHost, sourcePort, dsnOptions)
+	targetDSN := fmt.Sprintf("%s:%s@tcp(%s:%s)/mysql%s", user, password, targetHost, targetPort, dsnOptions)
 
 	// Connect to source database
-	db1, err = connectWithRetry(sourceDSN, 3)
+	db1, err = connectWithRetry(ctx, sourceDSN, 3)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to source database %s:%s: %w", sourceHost, sourcePort, err)
 	}
 
 	// Connect to target database
-	db2, err = connectWithRetry(targetDSN, 3)
+	db2, err = connectWithRetry(ctx, targetDSN, 3)
 	if err != nil {
 		db1.Close() // Clean up source connection
 		return nil, nil, fmt.Errorf("failed to connect to target database %s:%s: %w", targetHost, targetPort, err)
@@ -90,29 +122,46 @@ func ConnectToDatabases(sourceHost, sourcePort, targetHost, targetPort string) (
 	return db1, db2, nil
 }
 
-// retryDatabaseOperation retries a database operation with exponential backoff
-func retryDatabaseOperation(operation func() error, maxRetries int) error {
+// isRetryableError reports whether an error is transient enough to retry:
+// broken/invalid connections, network errors, lock wait timeouts, deadlocks.
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		switch mysqlErr.Number {
+		case 1205, 1213: // ER_LOCK_WAIT_TIMEOUT, ER_LOCK_DEADLOCK
+			return true
+		}
+	}
+	return false
+}
+
+// retryDatabaseOperation retries a transient-failing database operation with backoff
+func retryDatabaseOperation(ctx context.Context, operation func() error, maxRetries int) error {
 	var err error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		err = operation()
 		if err == nil {
 			return nil
 		}
-
-		// Check if the error is retryable (connection-related errors)
-		if strings.Contains(err.Error(), "connection") ||
-			strings.Contains(err.Error(), "timeout") ||
-			strings.Contains(err.Error(), "broken pipe") ||
-			strings.Contains(err.Error(), "connection refused") {
-			if attempt == maxRetries {
-				return fmt.Errorf("operation failed after %d attempts: %w", maxRetries+1, err)
-			}
-			time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond) // Exponential backoff
-			continue
+		if !isRetryableError(err) {
+			return err
 		}
-
-		// For non-retryable errors, return immediately
-		return err
+		if attempt == maxRetries {
+			return fmt.Errorf("operation failed after %d attempts: %w", maxRetries+1, err)
+		}
+		if serr := sleepCtx(ctx, time.Duration(attempt+1)*100*time.Millisecond); serr != nil {
+			return serr
+		}
 	}
 	return err
 }

--- a/pkg/gtids/gtid.go
+++ b/pkg/gtids/gtid.go
@@ -2,8 +2,11 @@
 package gtids
 
 import (
+	"bufio"
+	"context"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,10 +37,15 @@ import (
 var (
 	singleValueInterval = regexp.MustCompile("^([0-9]+)$")
 	multiValueInterval  = regexp.MustCompile("^([0-9]+)[-]([0-9]+)$")
-	green               = color.New(color.FgGreen).SprintFunc()
-	red                 = color.New(color.FgRed).SprintFunc()
-	yellow              = color.New(color.FgYellow).SprintFunc()
-	blue                = color.New(color.FgBlue).SprintFunc()
+	// gtidEntryPattern matches a single exploded GTID entry (uuid:transaction-id).
+	// SET GTID_NEXT cannot be parameterized, so entries are validated against this
+	// before being interpolated into the statement.
+	gtidEntryPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}:[0-9]+$`)
+	versionPattern   = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)`)
+	green            = color.New(color.FgGreen).SprintFunc()
+	red              = color.New(color.FgRed).SprintFunc()
+	yellow           = color.New(color.FgYellow).SprintFunc()
+	blue             = color.New(color.FgBlue).SprintFunc()
 )
 
 // OracleGtidSetEntry represents an entry in a set of GTID ranges,
@@ -69,7 +77,7 @@ func (oge *OracleGtidSetEntry) String() string {
 	return fmt.Sprintf("%s:%s", oge.UUID, oge.Ranges)
 }
 
-// String returns a user-friendly string representation of this entry
+// Explode returns this entry as a list of single-transaction entries
 func (oge *OracleGtidSetEntry) Explode() (result [](*OracleGtidSetEntry)) {
 	intervals := strings.Split(oge.Ranges, ":")
 	for _, interval := range intervals {
@@ -85,22 +93,6 @@ func (oge *OracleGtidSetEntry) Explode() (result [](*OracleGtidSetEntry)) {
 	}
 	return result
 }
-
-/*
-   Copyright 2015 Shlomi Noach, courtesy Booking.com
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
 
 // OracleGtidSet represents a set of GTID ranges as depicted by Retrieved_Gtid_Set, Executed_Gtid_Set or @@gtid_purged.
 type OracleGtidSet struct {
@@ -189,7 +181,7 @@ func (ogs *OracleGtidSet) SharedUUIDs(other *OracleGtidSet) (shared []string) {
 	return shared
 }
 
-// String returns a user-friendly string representation of this entry
+// Explode returns the set as a list of single-transaction entries
 func (ogs *OracleGtidSet) Explode() (result [](*OracleGtidSetEntry)) {
 	for _, entries := range ogs.GtidEntries {
 		result = append(result, entries.Explode()...)
@@ -209,18 +201,17 @@ func (ogs *OracleGtidSet) IsEmpty() bool {
 	return len(ogs.GtidEntries) == 0
 }
 
-// function to check the GTID set subset issue and fix it if the -fix flag is set
 // getServerInfo retrieves the server UUID and GTID_EXECUTED from a database connection
-func getServerInfo(db *sql.DB) (uuid, gtidExecuted string, err error) {
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("SELECT @@server_uuid").Scan(&uuid)
+func getServerInfo(ctx context.Context, db *sql.DB) (uuid, gtidExecuted string, err error) {
+	err = retryDatabaseOperation(ctx, func() error {
+		return db.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&uuid)
 	}, 3)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get server UUID: %w", err)
 	}
 
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("SELECT @@GLOBAL.GTID_EXECUTED").Scan(&gtidExecuted)
+	err = retryDatabaseOperation(ctx, func() error {
+		return db.QueryRowContext(ctx, "SELECT @@GLOBAL.GTID_EXECUTED").Scan(&gtidExecuted)
 	}, 3)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get GTID_EXECUTED: %w", err)
@@ -230,9 +221,9 @@ func getServerInfo(db *sql.DB) (uuid, gtidExecuted string, err error) {
 }
 
 // checkErrantTransactions uses gtid_subtract to find transactions that exist on target but not on source
-func checkErrantTransactions(targetGtid, sourceGtid string, db *sql.DB) (errant string, err error) {
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("select gtid_subtract('" + targetGtid + "','" + sourceGtid + "') as errant_transactions").Scan(&errant)
+func checkErrantTransactions(ctx context.Context, targetGtid, sourceGtid string, db *sql.DB) (errant string, err error) {
+	err = retryDatabaseOperation(ctx, func() error {
+		return db.QueryRowContext(ctx, "SELECT gtid_subtract(?, ?) AS errant_transactions", targetGtid, sourceGtid).Scan(&errant)
 	}, 3)
 	if err != nil {
 		return "", fmt.Errorf("failed to check errant transactions: %w", err)
@@ -241,9 +232,9 @@ func checkErrantTransactions(targetGtid, sourceGtid string, db *sql.DB) (errant 
 }
 
 // checkMissingTransactions uses gtid_subtract to find transactions that exist on source but not on target
-func checkMissingTransactions(sourceGtid, targetGtid string, db *sql.DB) (missing string, err error) {
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("select gtid_subtract('" + sourceGtid + "','" + targetGtid + "') as missing_transactions").Scan(&missing)
+func checkMissingTransactions(ctx context.Context, sourceGtid, targetGtid string, db *sql.DB) (missing string, err error) {
+	err = retryDatabaseOperation(ctx, func() error {
+		return db.QueryRowContext(ctx, "SELECT gtid_subtract(?, ?) AS missing_transactions", sourceGtid, targetGtid).Scan(&missing)
 	}, 3)
 	if err != nil {
 		return "", fmt.Errorf("failed to check missing transactions: %w", err)
@@ -251,24 +242,78 @@ func checkMissingTransactions(sourceGtid, targetGtid string, db *sql.DB) (missin
 	return missing, nil
 }
 
-// getBinaryLogInfo retrieves binary log information from SHOW MASTER STATUS
-func getBinaryLogInfo(db *sql.DB) (logName string, executedGtidSet string, err error) {
-	var pos int
-	var Binlog_Do_DB string
-	var Binlog_Ignore_DB string
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("SHOW MASTER STATUS").Scan(&logName, &pos, &Binlog_Do_DB, &Binlog_Ignore_DB, &executedGtidSet)
-	}, 3)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get binary log info: %w", err)
+// getBinaryLogInfo retrieves the current binary log file name.
+// MySQL 8.4 removed SHOW MASTER STATUS in favor of SHOW BINARY LOG STATUS
+// (available since 8.2), so try the new statement first and fall back.
+func getBinaryLogInfo(ctx context.Context, db *sql.DB) (logName string, err error) {
+	for _, stmt := range []string{"SHOW BINARY LOG STATUS", "SHOW MASTER STATUS"} {
+		logName, err = queryColumnByName(ctx, db, stmt, "File")
+		if err == nil {
+			return logName, nil
+		}
 	}
-	return logName, executedGtidSet, nil
+	return "", fmt.Errorf("failed to get binary log info: %w", err)
+}
+
+// queryColumnByName runs a query and returns the named column from the first row,
+// scanning dynamically so column count/order differences across versions don't matter.
+func queryColumnByName(ctx context.Context, db *sql.DB, query, column string) (string, error) {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("%s returned no rows", query)
+	}
+	columns, err := scanRowAsMap(rows)
+	if err != nil {
+		return "", err
+	}
+	value, ok := columns[column]
+	if !ok {
+		return "", fmt.Errorf("column %s not found in %s output", column, query)
+	}
+	return value, nil
+}
+
+// scanRowAsMap scans the current row of rows into a column-name -> string map.
+func scanRowAsMap(rows *sql.Rows) (map[string]string, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	values := make([]any, len(cols))
+	scanArgs := make([]any, len(cols))
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+	if err := rows.Scan(scanArgs...); err != nil {
+		return nil, err
+	}
+	columns := make(map[string]string, len(cols))
+	for i, colName := range cols {
+		switch v := values[i].(type) {
+		case nil:
+			columns[colName] = "NULL"
+		case []byte:
+			columns[colName] = string(v)
+		case string:
+			columns[colName] = v
+		default:
+			columns[colName] = fmt.Sprintf("%v", v)
+		}
+	}
+	return columns, nil
 }
 
 // parseErrantTransactions explodes the errant GTID set into individual entries
 func parseErrantTransactions(errant string) ([]string, error) {
-	gtidSet := errant
-	oracleGtidSet, err := NewOracleGtidSet(gtidSet)
+	oracleGtidSet, err := NewOracleGtidSet(errant)
 	if err != nil {
 		return nil, err
 	}
@@ -281,184 +326,198 @@ func parseErrantTransactions(errant string) ([]string, error) {
 	return entries, nil
 }
 
+// replicationCommandsForVersion picks STOP/START SLAVE vs REPLICA statements.
+// MySQL 8.0.22 introduced the REPLICA statements; 8.4 removed the SLAVE ones.
+// MariaDB keeps the SLAVE statements (and has an incompatible GTID scheme anyway).
+func replicationCommandsForVersion(version string) (stopCmd, startCmd, statusCmd string) {
+	if !strings.Contains(strings.ToLower(version), "mariadb") {
+		if m := versionPattern.FindStringSubmatch(version); m != nil {
+			major, _ := strconv.Atoi(m[1])
+			minor, _ := strconv.Atoi(m[2])
+			patch, _ := strconv.Atoi(m[3])
+			if major > 8 || (major == 8 && (minor > 0 || patch >= 22)) {
+				return "STOP REPLICA", "START REPLICA", "SHOW REPLICA STATUS"
+			}
+		}
+	}
+	return "STOP SLAVE", "START SLAVE", "SHOW SLAVE STATUS"
+}
+
 // determineReplicationCommands determines the correct replication commands based on MySQL version
-func determineReplicationCommands(db *sql.DB) (stopCmd, startCmd, statusCmd string, err error) {
+func determineReplicationCommands(ctx context.Context, db *sql.DB) (stopCmd, startCmd, statusCmd string, err error) {
 	var version string
-	err = retryDatabaseOperation(func() error {
-		return db.QueryRow("SELECT VERSION()").Scan(&version)
+	err = retryDatabaseOperation(ctx, func() error {
+		return db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version)
 	}, 3)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to get MySQL version: %w", err)
 	}
-
-	// MySQL 8.0.22+ uses STOP REPLICA, older versions use STOP SLAVE
-	if strings.Contains(version, "8.0") {
-		// Extract version number to check if >= 8.0.22
-		re := regexp.MustCompile(`8\.0\.(\d+)`)
-		matches := re.FindStringSubmatch(version)
-		if len(matches) > 1 {
-			if minorVersion, err := strconv.Atoi(matches[1]); err == nil && minorVersion >= 22 {
-				return "STOP REPLICA", "START REPLICA", "SHOW REPLICA STATUS", nil
-			}
-		}
-	}
-	return "STOP SLAVE", "START SLAVE", "SHOW SLAVE STATUS", nil
+	stopCmd, startCmd, statusCmd = replicationCommandsForVersion(version)
+	return stopCmd, startCmd, statusCmd, nil
 }
 
-// applyGtidFixes applies the errant GTID entries to the specified database
-func applyGtidFixes(db *sql.DB, entries []string, fixLocation string) error {
+// Options controls the fix behavior of CheckGtidSetSubset.
+type Options struct {
+	Fix               bool // apply errant GTIDs to the source
+	FixReplica        bool // apply errant GTIDs to the replica
+	FixMissingReplica bool // mark missing GTIDs as executed on the replica (skips their data)
+	DryRun            bool // print the statements a fix would run without executing them
+	AssumeYes         bool // skip the confirmation prompt
+}
+
+// confirmAction prompts on stdin before a destructive operation. Non-interactive
+// runs (closed stdin, cron) hit EOF and abort — pass -yes to skip the prompt.
+func confirmAction(prompt string, assumeYes bool) bool {
+	if assumeYes {
+		return true
+	}
+	fmt.Printf("%s %s Type 'yes' to continue (or pass -yes to skip this prompt): ", yellow("[?]"), prompt)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		fmt.Println("\nNo confirmation received — aborting.")
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}
+
+// printGtidStatements prints the empty-transaction sequence a fix would execute.
+func printGtidStatements(entries []string) {
 	for _, entry := range entries {
-		err := retryDatabaseOperation(func() error {
-			_, err := db.Exec("SET GTID_NEXT='" + entry + "'")
-			return err
-		}, 3)
-		if err != nil {
+		fmt.Printf("    SET GTID_NEXT='%s'; BEGIN; COMMIT;\n", entry)
+	}
+	fmt.Println("    SET GTID_NEXT='AUTOMATIC';")
+}
+
+// dryRunSourceFix prints what applyGtidsToSource would execute.
+func dryRunSourceFix(entries []string) {
+	fmt.Println(yellow("[dry-run]"), "Would execute on source (single pinned session):")
+	printGtidStatements(entries)
+}
+
+// dryRunReplicaFix prints what applyGtidsToReplica would execute.
+func dryRunReplicaFix(ctx context.Context, db *sql.DB, entries []string) error {
+	stopCmd, startCmd, _, err := determineReplicationCommands(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to determine replication commands: %w", err)
+	}
+	fmt.Println(yellow("[dry-run]"), "Would execute on replica (single pinned session):")
+	fmt.Printf("    %s;\n", stopCmd)
+	fmt.Println("    SET SESSION sql_log_bin = 0;")
+	printGtidStatements(entries)
+	fmt.Println("    SET SESSION sql_log_bin = 1;")
+	fmt.Printf("    %s;\n", startCmd)
+	return nil
+}
+
+// applyGtidEntries injects an empty transaction for each GTID entry on a single
+// pinned connection. GTID_NEXT is session-scoped, so every statement in the
+// sequence must run on the same connection — never on the *sql.DB pool.
+// GTID_NEXT is always reset to AUTOMATIC before returning, even on failure.
+func applyGtidEntries(ctx context.Context, conn *sql.Conn, entries []string, fixLocation string) (err error) {
+	defer func() {
+		// Cleanup must run even if ctx was cancelled (e.g. Ctrl-C mid-apply).
+		cleanupCtx := context.WithoutCancel(ctx)
+		if _, resetErr := conn.ExecContext(cleanupCtx, "SET GTID_NEXT='AUTOMATIC'"); resetErr != nil && err == nil {
+			err = fmt.Errorf("failed to reset GTID_NEXT to AUTOMATIC: %w", resetErr)
+		}
+	}()
+
+	for _, entry := range entries {
+		if !gtidEntryPattern.MatchString(entry) {
+			return fmt.Errorf("refusing to apply invalid GTID entry %q", entry)
+		}
+		if _, err := conn.ExecContext(ctx, "SET GTID_NEXT='"+entry+"'"); err != nil {
 			return fmt.Errorf("failed to set GTID_NEXT for %s: %w", entry, err)
 		}
-
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("BEGIN")
-			return err
-		}, 3)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, "BEGIN"); err != nil {
 			return fmt.Errorf("failed to begin transaction for %s: %w", entry, err)
 		}
-
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("COMMIT")
-			return err
-		}, 3)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 			return fmt.Errorf("failed to commit transaction for %s: %w", entry, err)
 		}
-
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("SET GTID_NEXT='AUTOMATIC'")
-			return err
-		}, 3)
-		if err != nil {
-			return fmt.Errorf("failed to reset GTID_NEXT for %s: %w", entry, err)
-		}
-
 		fmt.Printf("Applied entry to %s: %s\n", fixLocation, entry)
 	}
 	return nil
 }
 
-// applyMissingGtidFixes applies the missing GTID entries to the replica
-func applyMissingGtidFixes(db *sql.DB, entries []string, fixLocation string) error {
-	// Determine replication commands
-	stopCmd, startCmd, statusCmd, err := determineReplicationCommands(db)
+// applyGtidsToSource injects empty transactions on the source (binary logging
+// stays on so the GTIDs replicate downstream, where they are auto-skipped).
+func applyGtidsToSource(ctx context.Context, db *sql.DB, entries []string) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	fmt.Println("Applying errant GTIDs to source...")
+	return applyGtidEntries(ctx, conn, entries, "source")
+}
+
+// applyGtidsToReplica stops replication, injects empty transactions with binary
+// logging disabled on the session, then restarts replication and verifies it.
+// Replication is restarted even if applying the entries fails or ctx is cancelled.
+func applyGtidsToReplica(ctx context.Context, db *sql.DB, entries []string, fixLocation string, errantTransactions string) error {
+	stopCmd, startCmd, statusCmd, err := determineReplicationCommands(ctx, db)
 	if err != nil {
 		return fmt.Errorf("failed to determine replication commands: %w", err)
 	}
 
-	// Stop replication
+	// Cleanup must run even if ctx is cancelled mid-fix (e.g. Ctrl-C).
+	cleanupCtx := context.WithoutCancel(ctx)
+
 	fmt.Printf("Stopping replication on %s...\n", fixLocation)
-	_, err = db.Exec(stopCmd)
-	if err != nil {
+	if _, err := db.ExecContext(ctx, stopCmd); err != nil {
 		return fmt.Errorf("failed to stop replication on %s: %w", fixLocation, err)
 	}
 
-	// Disable binary logging
-	fmt.Printf("Disabling binary logging on %s...\n", fixLocation)
-	_, err = db.Exec("SET sql_log_bin = 0")
-	if err != nil {
-		log.Printf("Warning: Failed to disable binary logging: %v\n", err)
-	}
-
-	fmt.Printf("Applying missing GTIDs to %s...\n", fixLocation)
-
-	for _, entry := range entries {
-		err := retryDatabaseOperation(func() error {
-			_, err := db.Exec("SET GTID_NEXT='" + entry + "'")
-			return err
-		}, 3)
+	applyErr := func() error {
+		conn, err := db.Conn(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to set GTID_NEXT for %s: %w", entry, err)
+			return fmt.Errorf("failed to acquire connection: %w", err)
 		}
+		defer conn.Close()
 
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("BEGIN")
-			return err
-		}, 3)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction for %s: %w", entry, err)
+		fmt.Printf("Disabling binary logging on %s...\n", fixLocation)
+		if _, err := conn.ExecContext(ctx, "SET SESSION sql_log_bin = 0"); err != nil {
+			log.Printf("Warning: failed to disable binary logging: %v", err)
 		}
+		defer func() {
+			if _, err := conn.ExecContext(cleanupCtx, "SET SESSION sql_log_bin = 1"); err != nil {
+				log.Printf("Warning: failed to re-enable binary logging: %v", err)
+			}
+		}()
 
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("COMMIT")
-			return err
-		}, 3)
-		if err != nil {
-			return fmt.Errorf("failed to commit transaction for %s: %w", entry, err)
-		}
+		fmt.Printf("Applying GTIDs to %s...\n", fixLocation)
+		return applyGtidEntries(ctx, conn, entries, fixLocation)
+	}()
 
-		err = retryDatabaseOperation(func() error {
-			_, err := db.Exec("SET GTID_NEXT='AUTOMATIC'")
-			return err
-		}, 3)
-		if err != nil {
-			return fmt.Errorf("failed to reset GTID_NEXT for %s: %w", entry, err)
-		}
-
-		fmt.Printf("Applied missing entry to %s: %s\n", fixLocation, entry)
-	}
-
-	// Re-enable binary logging
-	fmt.Printf("Re-enabling binary logging on %s...\n", fixLocation)
-	_, err = db.Exec("SET sql_log_bin = 1")
-	if err != nil {
-		return fmt.Errorf("failed to re-enable binary logging on %s: %w", fixLocation, err)
-	}
-
-	// Start replication
 	fmt.Printf("Starting replication on %s...\n", fixLocation)
-	_, err = db.Exec(startCmd)
-	if err != nil {
+	if _, err := db.ExecContext(cleanupCtx, startCmd); err != nil {
+		if applyErr != nil {
+			return fmt.Errorf("applying GTIDs failed (%v) and replication could not be restarted on %s: %w", applyErr, fixLocation, err)
+		}
 		return fmt.Errorf("failed to start replication on %s: %w", fixLocation, err)
 	}
-
-	// Wait and verify
-	fmt.Printf("Waiting for replication to initialize...\n")
-	time.Sleep(2 * time.Second)
-
-	fmt.Printf("Verifying replication status on %s...\n", fixLocation)
-	err = verifyReplicationStatus(db, statusCmd, fixLocation, "")
-	if err != nil {
-		return fmt.Errorf("failed to verify replication status on %s: %w", fixLocation, err)
+	if applyErr != nil {
+		return fmt.Errorf("failed to apply GTIDs to %s: %w", fixLocation, applyErr)
 	}
 
-	return nil
+	fmt.Println("Waiting for replication to initialize...")
+	if err := sleepCtx(ctx, 2*time.Second); err != nil {
+		return err
+	}
+
+	fmt.Printf("Verifying replication status on %s...\n", fixLocation)
+	return verifyReplicationStatus(ctx, db, statusCmd, fixLocation, errantTransactions)
 }
 
 // verifyReplicationStatus checks and reports the replication status after fixes
-func verifyReplicationStatus(db *sql.DB, statusCmd string, fixLocation string, errantTransactions string) error {
-	// Try a simpler query first to verify connection is working
-	var testVar string
-	err := retryDatabaseOperation(func() error {
-		return db.QueryRow("SELECT @@version").Scan(&testVar)
-	}, 3)
-	if err != nil {
-		fmt.Printf("Debug: Error querying version: %v\n", err)
-	} else {
-		fmt.Printf("Debug: Connected to MySQL version: %s\n", testVar)
-	}
-
-	// Enhanced replication status reporting with more robust handling
-	var masterHost, retrievedGtidSet, executedGtidSet, sqlRunningState string
-	var ioRunning, sqlRunning string
-	var secondsBehind sql.NullInt64
-
-	// Get column data as a map for easier access
-	columns := make(map[string]string)
-
-	// Use SHOW SLAVE STATUS directly - works across all versions
-	fmt.Printf("Debug: Status command: %s\n", statusCmd)
+func verifyReplicationStatus(ctx context.Context, db *sql.DB, statusCmd string, fixLocation string, errantTransactions string) error {
 	var rows *sql.Rows
-	err = retryDatabaseOperation(func() error {
+	err := retryDatabaseOperation(ctx, func() error {
 		var err error
-		rows, err = db.Query(statusCmd)
+		rows, err = db.QueryContext(ctx, statusCmd)
 		return err
 	}, 3)
 	if err != nil {
@@ -466,120 +525,45 @@ func verifyReplicationStatus(db *sql.DB, statusCmd string, fixLocation string, e
 	}
 	defer rows.Close()
 
+	columns := map[string]string{}
 	if rows.Next() {
-		// Get column names
-		cols, err := rows.Columns()
-		if err != nil {
+		if columns, err = scanRowAsMap(rows); err != nil {
 			return err
-		}
-
-		fmt.Printf("Debug: Found %d columns in status output\n", len(cols))
-		fmt.Printf("Debug: Column names: %v\n", cols)
-
-		// Create a slice of interface{} to hold the values
-		values := make([]interface{}, len(cols))
-		scanArgs := make([]interface{}, len(cols))
-		for i := range values {
-			scanArgs[i] = &values[i]
-		}
-
-		// Scan the result into the values slice
-		err = rows.Scan(scanArgs...)
-		if err != nil {
-			return err
-		}
-
-		// Build a map of column name to string value
-		for i, colName := range cols {
-			var strVal string
-			val := values[i]
-
-			if val == nil {
-				strVal = "NULL"
-			} else {
-				switch v := val.(type) {
-				case []byte:
-					strVal = string(v)
-				case string:
-					strVal = v
-				case int64:
-					strVal = fmt.Sprintf("%d", v)
-					if colName == "Seconds_Behind_Master" {
-						secondsBehind.Int64 = v
-						secondsBehind.Valid = true
-					}
-				default:
-					strVal = fmt.Sprintf("%v", v)
-				}
-			}
-			columns[colName] = strVal
-		}
-
-		// Extract the values we need - handle both MySQL 5.7 and 8.0+ column names
-		if mh, ok := columns["Master_Host"]; ok {
-			masterHost = mh
-		} else if mh, ok := columns["Source_Host"]; ok {
-			masterHost = mh
-		}
-
-		if io, ok := columns["Slave_IO_Running"]; ok {
-			ioRunning = io
-		} else if io, ok := columns["Replica_IO_Running"]; ok {
-			ioRunning = io
-		}
-
-		if sql, ok := columns["Slave_SQL_Running"]; ok {
-			sqlRunning = sql
-		} else if sql, ok := columns["Replica_SQL_Running"]; ok {
-			sqlRunning = sql
-		}
-
-		if sbm, ok := columns["Seconds_Behind_Master"]; ok && sbm != "NULL" {
-			if sbmInt, err := strconv.ParseInt(sbm, 10, 64); err == nil {
-				secondsBehind.Int64 = sbmInt
-				secondsBehind.Valid = true
-			}
-		} else if sbm, ok := columns["Seconds_Behind_Source"]; ok && sbm != "NULL" {
-			if sbmInt, err := strconv.ParseInt(sbm, 10, 64); err == nil {
-				secondsBehind.Int64 = sbmInt
-				secondsBehind.Valid = true
-			}
-		}
-
-		if state, ok := columns["Slave_SQL_Running_State"]; ok {
-			sqlRunningState = state
-		} else if state, ok := columns["Replica_SQL_Running_State"]; ok {
-			sqlRunningState = state
-		}
-
-		if rgs, ok := columns["Retrieved_Gtid_Set"]; ok {
-			retrievedGtidSet = rgs
-		}
-
-		if egs, ok := columns["Executed_Gtid_Set"]; ok {
-			executedGtidSet = egs
 		}
 	}
 
-	// Print comprehensive replication status report
+	// Handle both MySQL 5.7/8.0 (Master/Slave) and 8.0.22+ (Source/Replica) column names.
+	pick := func(names ...string) string {
+		for _, name := range names {
+			if v, ok := columns[name]; ok {
+				return v
+			}
+		}
+		return ""
+	}
+	masterHost := pick("Master_Host", "Source_Host")
+	ioRunning := pick("Slave_IO_Running", "Replica_IO_Running")
+	sqlRunning := pick("Slave_SQL_Running", "Replica_SQL_Running")
+	secondsBehind := pick("Seconds_Behind_Master", "Seconds_Behind_Source")
+	sqlRunningState := pick("Slave_SQL_Running_State", "Replica_SQL_Running_State")
+	retrievedGtidSet := pick("Retrieved_Gtid_Set")
+	executedGtidSet := pick("Executed_Gtid_Set")
+
 	fmt.Println("\nReplication Status:")
 	fmt.Printf("                 Master_Host: %s\n", masterHost)
 	fmt.Printf("            Slave_IO_Running: %s\n", ioRunning)
 	fmt.Printf("           Slave_SQL_Running: %s\n", sqlRunning)
-	if secondsBehind.Valid {
-		fmt.Printf("       Seconds_Behind_Master: %d\n", secondsBehind.Int64)
-	} else {
-		fmt.Printf("       Seconds_Behind_Master: NULL\n")
-	}
+	fmt.Printf("       Seconds_Behind_Master: %s\n", secondsBehind)
 	fmt.Printf("     Slave_SQL_Running_State: %s\n", sqlRunningState)
 	fmt.Printf("          Retrieved_Gtid_Set: %s\n", retrievedGtidSet)
 	fmt.Printf("           Executed_Gtid_Set: %s\n", executedGtidSet)
 
-	// Still keep the simple status indicator
 	if ioRunning == "Yes" && sqlRunning == "Yes" {
 		fmt.Printf("%s Replication is running on %s\n", green("[+]"), fixLocation)
-		fmt.Printf("%s Note: Applied errant GTID %s to %s, but it will still show as errant until applied to source\n",
-			blue("[i]"), errantTransactions, fixLocation)
+		if errantTransactions != "" {
+			fmt.Printf("%s Note: Applied errant GTID %s to %s, but it will still show as errant until applied to source\n",
+				blue("[i]"), errantTransactions, fixLocation)
+		}
 	} else {
 		fmt.Printf("%s Replication issue on %s\n", red("[-]"), fixLocation)
 	}
@@ -587,182 +571,116 @@ func verifyReplicationStatus(db *sql.DB, statusCmd string, fixLocation string, e
 	return nil
 }
 
-func CheckGtidSetSubset(db1 *sql.DB, db2 *sql.DB, source string, target string, fix bool, fixReplica bool, fixMissingReplica bool) error {
-	var sourceGtidSet string
-	var targetGtidSet string
-	var errantTransactions string
-	var sourceUUID, targetUUID string
-
-	// Get server information for source
-	sourceUUID, sourceGtidSet, err := getServerInfo(db1)
+// CheckGtidSetSubset compares GTID_EXECUTED between source and target, reports
+// errant/missing transactions, and optionally fixes them per opts.
+// unresolved reports whether errant or missing transactions remain after the run
+// (found in check-only mode, shown in dry-run, or left when a fix was declined).
+func CheckGtidSetSubset(ctx context.Context, db1 *sql.DB, db2 *sql.DB, source string, target string, opts Options) (unresolved bool, err error) {
+	sourceUUID, sourceGtidSet, err := getServerInfo(ctx, db1)
 	if err != nil {
-		return fmt.Errorf("failed to get source server info: %w", err)
+		return false, fmt.Errorf("failed to get source server info: %w", err)
 	}
 
-	// Get server information for target
-	targetUUID, targetGtidSet, err = getServerInfo(db2)
+	targetUUID, targetGtidSet, err := getServerInfo(ctx, db2)
 	if err != nil {
-		return fmt.Errorf("failed to get target server info: %w", err)
+		return false, fmt.Errorf("failed to get target server info: %w", err)
 	}
 
-	// Print source information
 	fmt.Println(blue("[+]"), "Source ->", source, "gtid_executed:", sourceGtidSet)
 	fmt.Println(blue("[+]"), "server_uuid:", sourceUUID)
+	fmt.Println(yellow("[+]"), "Target ->", target, "gtid_executed:", targetGtidSet)
+	fmt.Println(yellow("[+]"), "server_uuid:", targetUUID)
 
-	// Process each target host (though currently only one db2 connection is used)
-	targetHosts := strings.Split(target, ",")
-	for _, targetHost := range targetHosts {
-		// Re-get target GTID set (in case of multiple targets, but logic seems to assume single target)
-		_, targetGtidSet, err = getServerInfo(db2)
+	errantTransactions, err := checkErrantTransactions(ctx, targetGtidSet, sourceGtidSet, db2)
+	if err != nil {
+		return false, fmt.Errorf("failed to check errant transactions: %w", err)
+	}
+
+	if errantTransactions == "" {
+		fmt.Println(green("[+]"), "No Errant Transactions:", errantTransactions)
+	} else {
+		unresolved = true
+		fmt.Println(red("[-]"), "Errant Transactions:", errantTransactions)
+
+		logName, err := getBinaryLogInfo(ctx, db2)
 		if err != nil {
-			return fmt.Errorf("failed to get target server info for %s: %w", targetHost, err)
+			return unresolved, fmt.Errorf("failed to get binary log info: %w", err)
 		}
+		fmt.Println(yellow("[-]"), "Errant Transaction Found in Log Name:", logName)
 
-		fmt.Println(yellow("[+]"), "Target ->", targetHost, "gtid_executed:", targetGtidSet)
-		fmt.Println(yellow("[+]"), "server_uuid:", targetUUID)
-
-		// Check for errant transactions
-		errantTransactions, err = checkErrantTransactions(targetGtidSet, sourceGtidSet, db2)
-		if err != nil {
-			return fmt.Errorf("failed to check errant transactions: %w", err)
-		}
-
-		if errantTransactions == "" {
-			fmt.Println(green("[+]"), "No Errant Transactions:", errantTransactions)
-		} else {
-			fmt.Println(red("[-]"), "Errant Transactions:", errantTransactions)
-
-			// Get binary log information
-			logName, executedGtidSet, err := getBinaryLogInfo(db2)
-			if err != nil {
-				return fmt.Errorf("failed to get binary log info: %w", err)
-			}
-
-			// Preserve the exact regex logic (even if it seems incorrect)
-			re := regexp.MustCompile("Errant Transactions: ([0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}:[0-9]+)")
-			matches := re.FindStringSubmatch(executedGtidSet)
-			if len(matches) > 0 {
-				errantTransactions = matches[1]
-			}
-			fmt.Println(yellow("[-]"), "Errant Transaction Found in Log Name:", logName)
-
-			// Parse errant transactions into entries
+		if opts.Fix || opts.FixReplica {
 			entries, err := parseErrantTransactions(errantTransactions)
 			if err != nil {
-				return fmt.Errorf("failed to parse errant transactions: %w", err)
+				return unresolved, fmt.Errorf("failed to parse errant transactions: %w", err)
 			}
 
-			// Only attempt fixes if there are errant transactions AND fix flag is set
-			if (fix || fixReplica) && len(entries) > 0 {
-				var targetDB *sql.DB
-				var fixLocation string
-				var stopCmd, startCmd, statusCmd string
-
-				if fixReplica {
-					targetDB = db2
-					fixLocation = "replica"
-
-					fmt.Printf("Debug: fixReplica is true, will apply to replica\n")
-					fmt.Printf("Stopping replication on %s...\n", fixLocation)
-
-					// Determine replication commands based on MySQL version
-					stopCmd, startCmd, statusCmd, err = determineReplicationCommands(targetDB)
-					if err != nil {
-						return fmt.Errorf("failed to determine replication commands: %w", err)
+			if len(entries) > 0 {
+				switch {
+				case opts.FixReplica && opts.DryRun:
+					if err := dryRunReplicaFix(ctx, db2, entries); err != nil {
+						return unresolved, err
 					}
-
-					_, err = targetDB.Exec(stopCmd)
-					if err != nil {
-						return fmt.Errorf("failed to stop replication on %s: %w", fixLocation, err)
+				case opts.FixReplica:
+					prompt := fmt.Sprintf("About to apply %d empty transaction(s) on the REPLICA %s (replication will be stopped and restarted).", len(entries), target)
+					if !confirmAction(prompt, opts.AssumeYes) {
+						fmt.Println(yellow("[i]"), "Skipped applying errant GTIDs to replica.")
+						break
 					}
-					fmt.Printf("Replication stopped on %s\n", fixLocation)
-
-					// Make sure binary logging is disabled for this session
-					fmt.Printf("Disabling binary logging on %s...\n", fixLocation)
-					_, err = targetDB.Exec("SET sql_log_bin = 0")
-					if err != nil {
-						log.Printf("Warning: Failed to disable binary logging: %v\n", err)
-						// Continue anyway, as this might be allowed in some setups
+					if err := applyGtidsToReplica(ctx, db2, entries, "replica", errantTransactions); err != nil {
+						return unresolved, err
 					}
-				} else {
-					targetDB = db1
-					fixLocation = "source"
-					if fix {
-						fmt.Printf("Debug: fix is true, will apply to source\n")
-					} else {
-						fmt.Printf("Debug: Neither fix nor fixReplica is true\n")
+					unresolved = false
+				case opts.DryRun:
+					dryRunSourceFix(entries)
+				default:
+					prompt := fmt.Sprintf("About to apply %d empty transaction(s) on the SOURCE %s (they will replicate downstream).", len(entries), source)
+					if !confirmAction(prompt, opts.AssumeYes) {
+						fmt.Println(yellow("[i]"), "Skipped applying errant GTIDs to source.")
+						break
 					}
+					if err := applyGtidsToSource(ctx, db1, entries); err != nil {
+						return unresolved, err
+					}
+					unresolved = false
 				}
-
-				fmt.Printf("Applying errant GTIDs to %s...\n", fixLocation)
-
-				// Actually disable binary logging AGAIN right before applying GTIDs if we're on replica
-				if fixReplica {
-					_, err := targetDB.Exec("SET SESSION sql_log_bin = 0")
-					if err != nil {
-						log.Printf("Warning: Failed to disable binary logging (retry): %v\n", err)
-					}
-				}
-
-				// Apply the GTID fixes
-				err = applyGtidFixes(targetDB, entries, fixLocation)
-				if err != nil {
-					return fmt.Errorf("failed to apply GTID fixes to %s: %w", fixLocation, err)
-				}
-
-				if fixReplica {
-					// Re-enable binary logging
-					fmt.Printf("Re-enabling binary logging on %s...\n", fixLocation)
-					_, err = targetDB.Exec("SET sql_log_bin = 1")
-					if err != nil {
-						return fmt.Errorf("failed to re-enable binary logging on %s: %w", fixLocation, err)
-					}
-
-					// Start replication after applying GTIDs
-					fmt.Printf("Starting replication on %s...\n", fixLocation)
-					_, err = targetDB.Exec(startCmd)
-					if err != nil {
-						return fmt.Errorf("failed to start replication on %s: %w", fixLocation, err)
-					}
-
-					// Add a delay to allow replication to start up fully
-					fmt.Printf("Waiting for replication to initialize...\n")
-					time.Sleep(2 * time.Second)
-
-					// Verify replication is working
-					fmt.Printf("Verifying replication status on %s...\n", fixLocation)
-
-					// Check replication status
-					err = verifyReplicationStatus(targetDB, statusCmd, fixLocation, errantTransactions)
-					if err != nil {
-						return fmt.Errorf("failed to verify replication status on %s: %w", fixLocation, err)
-					}
-				}
-			}
-		}
-
-		// Handle fixMissingReplica
-		if fixMissingReplica {
-			missingGtids, err := checkMissingTransactions(sourceGtidSet, targetGtidSet, db1) // Use db1 for the query
-			if err != nil {
-				return fmt.Errorf("failed to check missing transactions: %w", err)
-			}
-			if missingGtids != "" {
-				fmt.Printf("[-] Missing GTIDs: %s\n", missingGtids)
-
-				entries, err := parseErrantTransactions(missingGtids)
-				if err != nil {
-					return fmt.Errorf("failed to parse missing GTIDs: %w", err)
-				}
-
-				err = applyMissingGtidFixes(db2, entries, "replica")
-				if err != nil {
-					return fmt.Errorf("failed to apply missing GTID fixes: %w", err)
-				}
-			} else {
-				fmt.Println(green("[+]"), "No Missing GTIDs")
 			}
 		}
 	}
-	return nil
+
+	if opts.FixMissingReplica {
+		missingGtids, err := checkMissingTransactions(ctx, sourceGtidSet, targetGtidSet, db1)
+		if err != nil {
+			return unresolved, fmt.Errorf("failed to check missing transactions: %w", err)
+		}
+		if missingGtids != "" {
+			fmt.Println(red("[-]"), "Missing GTIDs:", missingGtids)
+			fmt.Println(red("[!]"), "WARNING: injecting empty transactions for missing GTIDs marks them as")
+			fmt.Println(red("[!]"), "executed WITHOUT applying their data — the source will never resend them.")
+			fmt.Println(red("[!]"), "The skipped transactions' data must be synced separately (e.g. data-diff).")
+
+			entries, err := parseErrantTransactions(missingGtids)
+			if err != nil {
+				return unresolved, fmt.Errorf("failed to parse missing GTIDs: %w", err)
+			}
+
+			if opts.DryRun {
+				unresolved = true
+				if err := dryRunReplicaFix(ctx, db2, entries); err != nil {
+					return unresolved, err
+				}
+			} else {
+				prompt := fmt.Sprintf("About to mark %d missing transaction(s) as executed on the REPLICA %s WITHOUT applying their data.", len(entries), target)
+				if !confirmAction(prompt, opts.AssumeYes) {
+					fmt.Println(yellow("[i]"), "Skipped applying missing GTIDs to replica.")
+					return true, nil
+				}
+				if err := applyGtidsToReplica(ctx, db2, entries, "replica", ""); err != nil {
+					return unresolved, fmt.Errorf("failed to apply missing GTID fixes: %w", err)
+				}
+			}
+		} else {
+			fmt.Println(green("[+]"), "No Missing GTIDs")
+		}
+	}
+	return unresolved, nil
 }

--- a/pkg/gtids/gtid_mock_test.go
+++ b/pkg/gtids/gtid_mock_test.go
@@ -1,0 +1,230 @@
+package gtids
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// Unit tests for the fix orchestration using a mocked database, so the
+// statement sequences are verified without a live MySQL instance.
+
+func TestApplyGtidEntries_StatementSequence(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	entries := []string{
+		"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1",
+		"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:2",
+	}
+
+	for _, entry := range entries {
+		mock.ExpectExec("SET GTID_NEXT='" + entry + "'").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("BEGIN").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("COMMIT").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+	mock.ExpectExec("SET GTID_NEXT='AUTOMATIC'").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("failed to acquire connection: %v", err)
+	}
+	defer conn.Close()
+
+	if err := applyGtidEntries(ctx, conn, entries, "test"); err != nil {
+		t.Fatalf("applyGtidEntries failed: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestApplyGtidEntries_RejectsInvalidEntry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Only the GTID_NEXT reset should run — the invalid entry must be
+	// rejected before any statement is sent.
+	mock.ExpectExec("SET GTID_NEXT='AUTOMATIC'").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("failed to acquire connection: %v", err)
+	}
+	defer conn.Close()
+
+	injections := []string{
+		"not-a-uuid:1",
+		"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1'; DROP TABLE users; --",
+		"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:",
+		"",
+	}
+	for _, bad := range injections {
+		if err := applyGtidEntries(ctx, conn, []string{bad}, "test"); err == nil {
+			t.Errorf("expected error for invalid entry %q, got nil", bad)
+		}
+	}
+}
+
+func TestApplyGtidEntries_ResetsGtidNextOnFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	entry := "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1"
+	mock.ExpectExec("SET GTID_NEXT='" + entry + "'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("BEGIN").WillReturnError(errors.New("server has gone away"))
+	// Even after the failure, GTID_NEXT must be reset to AUTOMATIC.
+	mock.ExpectExec("SET GTID_NEXT='AUTOMATIC'").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("failed to acquire connection: %v", err)
+	}
+	defer conn.Close()
+
+	if err := applyGtidEntries(ctx, conn, []string{entry}, "test"); err == nil {
+		t.Fatal("expected error from failed BEGIN, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("GTID_NEXT was not reset after failure: %v", err)
+	}
+}
+
+func TestGetBinaryLogInfo_FallsBackToShowMasterStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// MySQL < 8.2 doesn't know SHOW BINARY LOG STATUS.
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnError(errors.New("Error 1064 (42000): syntax error"))
+	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}).
+		AddRow("binlog.000042", 1234, "", "", "uuid:1-10")
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
+
+	logName, err := getBinaryLogInfo(context.Background(), db)
+	if err != nil {
+		t.Fatalf("getBinaryLogInfo failed: %v", err)
+	}
+	if logName != "binlog.000042" {
+		t.Errorf("expected binlog.000042, got %q", logName)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetBinaryLogInfo_PrefersShowBinaryLogStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// MySQL 8.4+ answers the new statement; the old one must not be issued.
+	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}).
+		AddRow("binlog.000007", 999, "", "", "uuid:1-10")
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(rows)
+
+	logName, err := getBinaryLogInfo(context.Background(), db)
+	if err != nil {
+		t.Fatalf("getBinaryLogInfo failed: %v", err)
+	}
+	if logName != "binlog.000007" {
+		t.Errorf("expected binlog.000007, got %q", logName)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDetermineReplicationCommands_Mock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT VERSION").
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("8.4.2"))
+
+	stop, start, status, err := determineReplicationCommands(context.Background(), db)
+	if err != nil {
+		t.Fatalf("determineReplicationCommands failed: %v", err)
+	}
+	if stop != "STOP REPLICA" || start != "START REPLICA" || status != "SHOW REPLICA STATUS" {
+		t.Errorf("expected REPLICA commands for 8.4.2, got %q / %q / %q", stop, start, status)
+	}
+}
+
+func TestVerifyReplicationStatus_ReplicaColumnNames(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// MySQL 8.0.22+ column names (Source/Replica instead of Master/Slave).
+	rows := sqlmock.NewRows([]string{
+		"Source_Host", "Replica_IO_Running", "Replica_SQL_Running",
+		"Seconds_Behind_Source", "Replica_SQL_Running_State",
+		"Retrieved_Gtid_Set", "Executed_Gtid_Set",
+	}).AddRow("10.0.0.1", "Yes", "Yes", 0, "waiting", "uuid:1-5", "uuid:1-5")
+	mock.ExpectQuery("SHOW REPLICA STATUS").WillReturnRows(rows)
+
+	err = verifyReplicationStatus(context.Background(), db, "SHOW REPLICA STATUS", "replica", "")
+	if err != nil {
+		t.Fatalf("verifyReplicationStatus failed: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRetryDatabaseOperation_NonRetryableFailsFast(t *testing.T) {
+	calls := 0
+	err := retryDatabaseOperation(context.Background(), func() error {
+		calls++
+		return errors.New("Error 1064 (42000): You have an error in your SQL syntax")
+	}, 3)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("non-retryable error should not be retried: got %d calls", calls)
+	}
+}
+
+func TestRetryDatabaseOperation_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A retryable error with a cancelled context must abort during backoff.
+	err := retryDatabaseOperation(ctx, func() error {
+		return &timeoutError{}
+	}, 3)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// timeoutError implements net.Error to exercise the retryable path.
+type timeoutError struct{}
+
+func (*timeoutError) Error() string   { return "i/o timeout" }
+func (*timeoutError) Timeout() bool   { return true }
+func (*timeoutError) Temporary() bool { return true }

--- a/pkg/gtids/gtid_test.go
+++ b/pkg/gtids/gtid_test.go
@@ -1,9 +1,11 @@
 package gtids
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -267,13 +269,33 @@ func TestOracleGtidSetEntry_Explode(t *testing.T) {
 	}
 }
 
-func TestDetermineReplicationCommands(t *testing.T) {
-	// Note: This test would require a mock database connection
-	// For now, we'll test the logic by examining the determineReplicationCommands function
-	// and ensuring it returns appropriate commands based on version strings
+func TestReplicationCommandsForVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		wantStop string
+	}{
+		{"5.7.44-log", "STOP SLAVE"},
+		{"8.0.21", "STOP SLAVE"},
+		{"8.0.22", "STOP REPLICA"},
+		{"8.0.32-24", "STOP REPLICA"},
+		{"8.4.0", "STOP REPLICA"},
+		{"9.1.0", "STOP REPLICA"},
+		{"10.11.6-MariaDB", "STOP SLAVE"},
+		{"garbage", "STOP SLAVE"},
+	}
 
-	// This is a placeholder - full testing would require database mocking
-	t.Skip("Database mocking required for full testing")
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			stop, start, status := replicationCommandsForVersion(tt.version)
+			if stop != tt.wantStop {
+				t.Errorf("version %q: expected %q, got %q", tt.version, tt.wantStop, stop)
+			}
+			wantPrefix := strings.TrimPrefix(tt.wantStop, "STOP ")
+			if !strings.HasSuffix(start, wantPrefix) || !strings.HasSuffix(status, "STATUS") {
+				t.Errorf("version %q: inconsistent commands: %q / %q / %q", tt.version, stop, start, status)
+			}
+		})
+	}
 }
 
 // DatabaseInterface defines the database operations we need for testing
@@ -302,7 +324,7 @@ func TestGetServerInfo_Integration(t *testing.T) {
 		t.Skip("Cannot ping test database:", err)
 	}
 
-	uuid, gtidExecuted, err := getServerInfo(db)
+	uuid, gtidExecuted, err := getServerInfo(context.Background(), db)
 	if err != nil {
 		t.Fatalf("getServerInfo failed: %v", err)
 	}
@@ -336,7 +358,7 @@ func TestCheckErrantTransactions_Integration(t *testing.T) {
 	}
 
 	// Test with identical GTID sets (should return empty string)
-	errant, err := checkErrantTransactions("1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", db)
+	errant, err := checkErrantTransactions(context.Background(), "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", db)
 	if err != nil {
 		t.Fatalf("checkErrantTransactions failed: %v", err)
 	}
@@ -346,7 +368,7 @@ func TestCheckErrantTransactions_Integration(t *testing.T) {
 	}
 
 	// Test with different GTID sets
-	errant, err = checkErrantTransactions("1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-5", db)
+	errant, err = checkErrantTransactions(context.Background(), "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-10", "1d1fff5a-c9bc-11ed-9c19-02a36d996b94:1-5", db)
 	if err != nil {
 		t.Fatalf("checkErrantTransactions failed: %v", err)
 	}
@@ -378,9 +400,16 @@ func TestApplyGtidFixes_Integration(t *testing.T) {
 	// Test with a simple GTID entry (using a valid UUID format)
 	entries := []string{"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:123"}
 
-	err = applyGtidFixes(db, entries, "test")
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		t.Fatalf("applyGtidFixes failed: %v", err)
+		t.Fatalf("failed to acquire connection: %v", err)
+	}
+	defer conn.Close()
+
+	err = applyGtidEntries(ctx, conn, entries, "test")
+	if err != nil {
+		t.Fatalf("applyGtidEntries failed: %v", err)
 	}
 
 	// If we get here, the function executed without error


### PR DESCRIPTION
## Summary

Full production-readiness pass tracked in `PRODUCTION_READINESS.md` (included). Verified end-to-end against a live MySQL 8.0 primary/replica pair.

### Correctness & safety (P0)
- **Pin fix sequences to a single connection** — `SET GTID_NEXT` / `sql_log_bin` / `BEGIN` / `COMMIT` previously ran on the `*sql.DB` pool and could land on different connections, committing under the wrong GTID or with binlogging still enabled
- **Guaranteed cleanup** on failure or Ctrl-C: reset `GTID_NEXT`, re-enable binlogging, restart replication (via `context.WithoutCancel`)
- **MySQL 8.4+/9.x support**: `SHOW BINARY LOG STATUS` fallback, proper `STOP/START REPLICA` version detection, MariaDB guard
- Parameterized `gtid_subtract` queries + strict GTID validation before `SET GTID_NEXT`
- Removed dead errant-regex block and the no-op multi-target loop

### UX & scriptability
- `-dry-run` prints the exact statements a fix would execute
- Confirmation prompt before every fix; `-yes` for automation (**breaking**: scripted `-fix` callers must add `-yes`)
- Exit codes: `0` in sync / fixed, `1` error, `2` errant/missing remain
- `-version` (wired to goreleaser ldflags), Ctrl-C/SIGTERM cancellation, DSN timeouts, `MYSQL_USER`/`MYSQL_PASSWORD` env credentials
- Loud data-loss warning on `-fix-missing-replica`

### Testing & CI
- sqlmock unit tests for the fix orchestration (statement sequence, injection rejection, cleanup-after-failure, 8.4 fallback, cancellation)
- CI: golangci-lint, docker-compose integration job, vet + unit tests before builds; weekly dependabot (gomod + actions)

### Docs
- README rewritten: flags, exit codes, recommended workflow, warnings, release walkthrough

## Test plan
- [x] `go vet`, `golangci-lint run`, `go test -short` all clean
- [x] Live verification against a real primary→replica pair: detection, `-fix`, dry-run, prompt abort (EOF + "no"), `-yes`, exit-code matrix, SIGINT mid-fix (replication survives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)